### PR TITLE
Update presence reading when unreachable

### DIFF
--- a/FHEM/17_SIRD.pm
+++ b/FHEM/17_SIRD.pm
@@ -2158,13 +2158,11 @@ sub SIRD_ParsePower($$$)
   if ('' ne $err)
   {
     Log3 $name, 5, $name.': Error while requesting '.$param->{url}.' - '.$err;
-    if ($param->{errno} == 113) { # 113: EHOSTUNREACH - No route to host.
-      readingsBeginUpdate($hash);
-      readingsBulkUpdate($hash, 'power', '');
-      readingsBulkUpdate($hash, 'presence', 'absent');
-      readingsBulkUpdate($hash, 'state', 'absent');
-      readingsEndUpdate($hash, 1);
-    }
+    readingsBeginUpdate($hash);
+    readingsBulkUpdate($hash, 'power', '');
+    readingsBulkUpdate($hash, 'presence', 'absent');
+    readingsBulkUpdate($hash, 'state', 'absent');
+    readingsEndUpdate($hash, 1);
   }
   elsif ('' ne $data)
   {

--- a/FHEM/17_SIRD.pm
+++ b/FHEM/17_SIRD.pm
@@ -2158,6 +2158,13 @@ sub SIRD_ParsePower($$$)
   if ('' ne $err)
   {
     Log3 $name, 5, $name.': Error while requesting '.$param->{url}.' - '.$err;
+    if ($param->{errno} == 113) { # 113: EHOSTUNREACH - No route to host.
+      readingsBeginUpdate($hash);
+      readingsBulkUpdate($hash, 'power', '');
+      readingsBulkUpdate($hash, 'presence', 'absent');
+      readingsBulkUpdate($hash, 'state', 'absent');
+      readingsEndUpdate($hash, 1);
+    }
   }
   elsif ('' ne $data)
   {


### PR DESCRIPTION
Update presence reading when unreachable

The variable [$errno](https://forum.fhem.de/index.php/topic,101695.0.html) is set when the SIRD device in unrechable. Unfortunately the variable is not set on timeout, thus it is not used in this patch. 

Closes #3 